### PR TITLE
SB-1423 - Fix parsing of the JSON response from the CWS API

### DIFF
--- a/publish-webstore.sh
+++ b/publish-webstore.sh
@@ -64,7 +64,7 @@ manage_api_response() {
     #2xx OK Status Code
     if [[ ${HTTP_CODE} =~ ^2[0-9]{2}$ ]]; then
 
-        STATUS=$(grep -Po '"'${EXPECTED_KEY}'":\[?"(\K[^"]*)' api-response.json)
+        STATUS=$(grep -Po '"'${EXPECTED_KEY}'":\s*\[?"(\K[^"]*)' api-response.json)
 
         #The JSON response contains the EXPECTED_KEY and EXPECTED_VALUE
         if [[ ${STATUS} == ${EXPECTED_VALUE} ]]; then


### PR DESCRIPTION
The response from the CWS API is now pretty formatted.

**Previous format**:
```
{"kind":"chromewebstore#item","id":"jdfejjabmfoicpgmajgllellipniiaml","uploadState":"SUCCESS"}
```
**New format**:
```
{
  "kind": "chromewebstore#item",
  "id": "jdfejjabmfoicpgmajgllellipniiaml",
  "uploadState": "SUCCESS"
}
```

We updated our regexp in charge of the `uploadState` extraction, to prevent false positive failure when this state value was checked.